### PR TITLE
Updated the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # TODO Application with Quarkus
 
+This is an example application based on a Todo list where the different tasks are created, read, updated, or deleted from the database. Default this application for convenience purposes uses an in-memory database called H2 that allows you to run this application without depending on an external database being available. However, the H2 database is not supported to run in native mode, so before you do the native compilation, you will have to switch to the `postgresql`  branch. 
 
-Branches:
-
+## Branches:
 * `master` - use H2 (in memory), no native support
 * `postgresql` - use posgresql, support native mode 
 
-## Compilation
+## Compile and run on a JVM
 
 ```bash
 mvn package
@@ -20,19 +20,20 @@ Then, open: http://localhost:8080/
 ```bash
 mvn compile quarkus:dev
 ```
-
 Then, open: http://localhost:8080/
 
-## Postgres - Run database
+## Compile to Native and run with PostgresSQL ( in a container )
 
+Compile:
+```bash
+git checkout --track origin/postgresql
+mvn clean package -Pnative
+```
 Run:
-
 ```bash
 docker run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 \
     --name postgres-quarkus-rest-http-crud -e POSTGRES_USER=restcrud \
     -e POSTGRES_PASSWORD=restcrud -e POSTGRES_DB=rest-crud \
     -p 5432:5432 postgres:10.5
+target/todo-backend-*-runner
 ```
-
-
-


### PR DESCRIPTION
I've update the readme to more better explain why we are using H2 as the default database and that users will have to switch to postgresql branch before compiling to a native app. I've also added a step to checkout the postgresql branch.