### PR TITLE
Update devfile to use devfile org rather then mloriedo

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -5,13 +5,15 @@ components:
   - name: tooling-container
     container:
       env:
+        - name: KUBEDOCK_ENABLED
+          value: 'true'
         - name: DOCKER_HOST
           value: 'tcp://127.0.0.1:2475'
-        - name: CONTAINER_HOST
-          value: 'tcp://127.0.0.1:2475'
+        - name: TESTCONTAINERS_RYUK_DISABLED
+          value: 'true'
         - name: QUARKUS_DATASOURCE_DEVSERVICES_VOLUMES_  # <-- https://quarkus.io/guides/databases-dev-services#quarkus-datasource-config-group-dev-services-build-time-config_quarkus.datasource.devservices.volumes-volumes
           value: '/var/lib/postgresql/'
-      image: quay.io/mloriedo/universal-developer-image:kubedock
+      image: quay.io/devfile/universal-developer-image:latest
       memoryRequest: 2Gi
       memoryLimit: 8Gi
       cpuRequest: 1000m
@@ -31,4 +33,4 @@ commands:
     exec:
       label: '2. Podman Run Sample'
       component: tooling-container
-      commandLine: podman --remote --url "tcp://127.0.0.1:2475" run --name httpd -d -p 8080:8080 python python -m http.server 8080
+      commandLine: podman run --name httpd -d -p 8080:8080 python python -m http.server 8080


### PR DESCRIPTION
Kubedock is part of `quay.io/devfile/universal-developer-image:latest` so it's possible to use that image instead of the one in my personal quay.io repo.

This change require a few other adjustments:

- Setting `KUBEDOCK_ENABLED=true` is needed to start the kubedock service at the workspace startup.
- The env variable `CONTAINER_HOST` is not needed anymore as it's automatically set when Kubedock is enabled.
- Setting `TESTCONTAINERS_RYUK_DISABLED=true` is useful to avoid some warnings at build time.
- And `podman run` doesn't need the parameters `--remote` and `--url "tcp://127.0.0.1:2475"` as they are set automatically.