### PR TITLE
Change quarkus.package.type to quarkus.native.enabled for native

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
             </activation>
             <properties>
                 <skipITs>false</skipITs>
-                <quarkus.package.type>native</quarkus.package.type>
+		<quarkus.native.enabled>true</quarkus.native.enabled>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
As app was updated to Quarkus 3.11 it should also change `quarkus.package.type` to `quarkus.native,enabled` see [migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.10#packaging-configuration-gear-white_check_mark)